### PR TITLE
#12 removing username password support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: required
 language: go
 go:
 - "1.11"
-script:
+install:
 - go get -u golang.org/x/lint/golint
+script:
 - golint skytap
 - make build
 - make test

--- a/skytap/credentials.go
+++ b/skytap/credentials.go
@@ -27,25 +27,6 @@ func NewNoOpCredentials() *NoOpCredentials {
 	return &NoOpCredentials{}
 }
 
-// PasswordCredentials describes the username password data
-type PasswordCredentials struct {
-	Username string
-	Password string
-}
-
-// Retrieve the username password data
-func (c *PasswordCredentials) Retrieve(ctx context.Context) (string, error) {
-	return buildBasicAuth(c.Username, c.Password), nil
-}
-
-// NewPasswordCredentials create a new username and password credentials instance
-func NewPasswordCredentials(username, password string) *PasswordCredentials {
-	return &PasswordCredentials{
-		Username: username,
-		Password: password,
-	}
-}
-
 // APITokenCredentials is ued when the credentials used are the username and api token data
 type APITokenCredentials struct {
 	Username string

--- a/skytap/credentials_test.go
+++ b/skytap/credentials_test.go
@@ -16,22 +16,6 @@ func TestNoOpCredentials(t *testing.T) {
 	assert.Equal(t, "", result)
 }
 
-func TestPasswordCredentials(t *testing.T) {
-	username := "user"
-	password := "password"
-	header := "Basic dXNlcjpwYXNzd29yZA=="
-
-	cred := NewPasswordCredentials(username, password)
-
-	assert.Equal(t, username, cred.Username)
-	assert.Equal(t, password, cred.Password)
-
-	result, err := cred.Retrieve(context.Background())
-
-	assert.NoError(t, err)
-	assert.Equal(t, header, result)
-}
-
 func TestApiTokenCredentials(t *testing.T) {
 	username := "user"
 	token := "token"

--- a/skytap/settings_test.go
+++ b/skytap/settings_test.go
@@ -21,17 +21,17 @@ func TestNewDefaultSettingsWithOpts(t *testing.T) {
 	baseURL := "https://url.com"
 	userAgent := "testclient/1.0.0"
 	username := "user"
-	password := "password"
+	token := "token"
 
 	settings := NewDefaultSettings(
 		WithBaseURL(baseURL),
-		WithCredentialsProvider(NewPasswordCredentials(username, password)))
+		WithCredentialsProvider(NewAPITokenCredentials(username, token)))
 
 	assert.Equal(t, baseURL, settings.baseURL)
 	assert.Equal(t, DefaultUserAgent, settings.userAgent)
 
 	if assert.NotNil(t, settings.credentials) {
-		assert.IsType(t, &PasswordCredentials{}, settings.credentials)
+		assert.IsType(t, &APITokenCredentials{}, settings.credentials)
 	}
 
 	settings = NewDefaultSettings(WithUserAgent(userAgent))


### PR DESCRIPTION
Username and password support is not provided by the Skytap API. This commit removes it from the SDK therefore. API Token authentication is still provided.

Please accept and merge the v2 PR first #5.